### PR TITLE
#2 - Handle skipped cols Joi conflict

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,11 +194,6 @@ exports.genMigrationFile = (options, cb) => {
                         const template = Fs.readFileSync(__dirname + '/hbs/migrationFileTemplate.hbs').toString();
                         const compiler = internals.handlebars().compile(template);
                         const createdTables = tableDeltas.tableDelta.create.concat(tableDeltas.joinTableDelta.create);
-                        const sameColumn = (skipA, skipB) => skipA.tableName === skipB.tableName && skipA.column === skipB.column && skipA.schemaConflict === skipB.schemaConflict;
-                        const dedupedSkippedCols = skippedCols.filter((skip, i) => {
-
-                            return skippedCols.findIndex((s) => sameColumn(s, skip)) === i;
-                        });
 
                         if (createdTables.length === 0 &&
                             columnDeltas.changes.length === 0) {
@@ -206,7 +201,7 @@ exports.genMigrationFile = (options, cb) => {
                             return cb(null, {
                                 code: exports.returnCodes.NO_MIGRATION,
                                 file: null,
-                                skippedColumns: dedupedSkippedCols
+                                skippedColumns: skippedCols
                             });
                         }
 
@@ -242,10 +237,17 @@ exports.genMigrationFile = (options, cb) => {
                                             return cb(err);
                                         }
 
+                                        let returnCode = exports.returnCodes.MIGRATION;
+                                        const schemaConflictExists = skippedCols.some((sc) => sc.schemaConflict);
+
+                                        if (schemaConflictExists) {
+                                            returnCode = exports.returnCodes.MIGRATION_WITH_CONFLICT;
+                                        }
+
                                         return cb(null, {
-                                            code: exports.returnCodes.MIGRATION,
+                                            code: returnCode,
                                             file: justCreatedMigrationPath,
-                                            skippedColumns: dedupedSkippedCols
+                                            skippedColumns: skippedCols
                                         });
                                     }
                                 );
@@ -385,18 +387,24 @@ internals.diffColumns = (migrationGroup, joinTables, mode, cb) => {
                     const type = dbSchema[column];
                     const [err] = Mappings.convertFuncs.getAliasVal(type);
                     if (err) {
-                        skippedCols.push({
-                            tableName,
-                            column,
-                            type,
-                            schemaConflict: Object.keys(modelKnexSchema).includes(column)
-                        });
+
+                        // The join tables have already been taken care of
+                        // so do not add to skippedCols
+
+                        if (!joinTablesAsModels.find((jt) => jt.tableName === tableName)) {
+                            skippedCols.push({
+                                tableName,
+                                column,
+                                type,
+                                schemaConflict: Object.keys(modelKnexSchema).includes(column)
+                            });
+                        }
                     }
                     return !err;
                 });
 
             // Filter out any skippedCols from the model's schema so they don't get diffed
-            // Note this is considered a conflict
+            // Note this is considered a schema conflict
             const filteredModelKnex2ColumnCompilerSchema = Object.keys(modelKnex2ColumnCompilerSchema)
                 .reduce((collector, colName) => {
 
@@ -559,14 +567,6 @@ internals.getJoinTableInfo = (model, knex, cb) => {
 
         const { modelClass, from, to, extra } = relation.join.through;
 
-        if (modelClass) {
-            joinTables.push({
-                tableName: modelClass.tableName,
-                joiSchema: modelClass.getJoiSchema()
-            });
-            return next();
-        }
-
         const joinTableFrom = from.split('.');
         const joinTableTo = to.split('.');
         const relationExtra = extra || Joi.object({});
@@ -587,11 +587,28 @@ internals.getJoinTableInfo = (model, knex, cb) => {
                         skippedCols.push({
                             tableName,
                             column,
-                            type
+                            type,
+                            schemaConflict: false // Set as a default, may be overridden below
                         });
                     }
                     return !err;
                 });
+
+            const joiKeysToStrip = skippedCols.map((sc) => sc.column);
+
+            // Update skippedCols to say there's a schemaConflict
+            const onKeyStripped = (keyName) => {
+
+                skippedCols.find((sc) => sc.column === keyName).schemaConflict = true;
+            };
+
+            if (modelClass) {
+                joinTables.push({
+                    tableName: modelClass.tableName,
+                    joiSchema: internals.stripKeysFromJoi(modelClass.getJoiSchema(), joiKeysToStrip, onKeyStripped)
+                });
+                return next();
+            }
 
             const db2JoiTypes = dbColsToConvert.reduce((collector, columnName) => {
 
@@ -619,6 +636,7 @@ internals.getJoinTableInfo = (model, knex, cb) => {
             toFromColumns[fromName] = Mappings.convertFuncs.string2Joi(db2JoiTypes[fromName] || 'any');
             toFromColumns[toName] = Mappings.convertFuncs.string2Joi(db2JoiTypes[toName] || 'any');
 
+            // relationExtra is just an empty Joi object here if it 'isJoi'
             let joiSchema = relationExtra.isJoi ? relationExtra : Joi.object(
                 relationExtra.reduce((collector, field) => {
 
@@ -629,6 +647,9 @@ internals.getJoinTableInfo = (model, knex, cb) => {
             );
 
             joiSchema = joiSchema.keys(toFromColumns);
+
+            // Strip out any skippedCols
+            joiSchema = internals.stripKeysFromJoi(joiSchema, joiKeysToStrip, onKeyStripped);
 
             joinTables.push({
                 tableName,
@@ -648,6 +669,8 @@ internals.getJoinTableInfo = (model, knex, cb) => {
     });
 };
 
+// Please note this interpretation of jsondiffpatch's output is
+// specific to schwifty-migrate-diff's use-case
 internals.getJsonDiffpatchChangeType = (change) => {
 
     switch (change.length) {
@@ -665,17 +688,34 @@ internals.getJsonDiffpatchChangeType = (change) => {
 
 internals.mergeJoiCompiled = (joiUncompiledSchema, joiCompiledSchema) => {
 
-    const describe = joiCompiledSchema.describe().children;
+    const describeChildren = joiCompiledSchema.describe().children;
 
-    const keysFromDescribe = Object.keys(describe)
+    const keysFromDescribe = Object.keys(describeChildren)
         .reduce((schema, keyName) => {
 
-            const type = describe[keyName].type;
-            schema[keyName] = Joi[type]();
+            const child = describeChildren[keyName];
+            schema[keyName] = Mappings.convertFuncs.string2Joi(Mappings.convertFuncs.stringFromJoiDescribeChild(child));
             return schema;
         }, {});
 
     return joiUncompiledSchema.keys(keysFromDescribe);
+};
+
+internals.stripKeysFromJoi = (joiCompiledSchema, keysToStrip, onKeyStripped) => {
+
+    const describeChildren = joiCompiledSchema.describe().children;
+    return Joi.object(Object.keys(describeChildren)
+        .reduce((schema, childName) => {
+
+            if (keysToStrip.includes(childName)) {
+                onKeyStripped(childName);
+            }
+            else {
+                const child = describeChildren[childName];
+                schema[childName] = Mappings.convertFuncs.string2Joi(Mappings.convertFuncs.stringFromJoiDescribeChild(child));
+            }
+            return schema;
+        }, {}));
 };
 
 internals.reduceErrors = (errors) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -569,7 +569,7 @@ internals.getJoinTableInfo = (model, knex, cb) => {
 
         const joinTableFrom = from.split('.');
         const joinTableTo = to.split('.');
-        const relationExtra = extra || Joi.object({});
+        const relationExtra = extra;
         const tableName = joinTableFrom[0];
 
         internals.getColumnsForTable(knex, tableName, (err, dbSchema) => {
@@ -596,12 +596,19 @@ internals.getJoinTableInfo = (model, knex, cb) => {
 
             const joiKeysToStrip = skippedCols.map((sc) => sc.column);
 
-            // Update skippedCols to say there's a schemaConflict
+            // Update skippedCols to say there's a schemaConflict in 'onKeyStripped'
+
+            // The Joi schemas don't know what's a conflict until the db types are checked above ^^^
+            // We also don't have the contents of the Joi schemas at the time we check the db types
             const onKeyStripped = (keyName) => {
 
+                // This find will never fail because the 'keyName' var passed in will
+                // always be based from an item in the skippedCols array. See 'joiKeysToStrip' above
                 skippedCols.find((sc) => sc.column === keyName).schemaConflict = true;
             };
 
+            // Special case for join tables, a join table may specify a model to describe
+            // its tableName and joiSchema. Return early if this is the case
             if (modelClass) {
                 joinTables.push({
                     tableName: modelClass.tableName,
@@ -630,14 +637,22 @@ internals.getJoinTableInfo = (model, knex, cb) => {
             }, {});
 
             const toFromColumns = {};
-            const fromName = joinTableFrom[1];
-            const toName = joinTableTo[1];
+            const fromName = joinTableFrom[1]; // tableName
+            const toName = joinTableTo[1]; // tableName
 
+            // Turn 'toFromColumns' into Joi keys to add to 'joiSchema' via 'joiSchema.keys()'
+
+            // Currently there is no way to give a type to these extra columns, just specify that
+            // they are there. For more control specifying types for extra columns, create a model
+            // for the join table and use the 'modelClass' prop.
+
+            // If there's already a column in the db that matches 'fromName' or 'toName', we use
+            // the type from the db for this schema partial. Fallback to 'any'
             toFromColumns[fromName] = Mappings.convertFuncs.string2Joi(db2JoiTypes[fromName] || 'any');
             toFromColumns[toName] = Mappings.convertFuncs.string2Joi(db2JoiTypes[toName] || 'any');
 
-            // relationExtra is just an empty Joi object here if it 'isJoi'
-            let joiSchema = relationExtra.isJoi ? relationExtra : Joi.object(
+            // relationExtra is the 'extra' property in Objection relationMappings (Array)
+            let joiSchema = !relationExtra ? Joi.object({}) : Joi.object(
                 relationExtra.reduce((collector, field) => {
 
                     return Object.assign({}, collector, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -636,6 +636,8 @@ internals.getJoinTableInfo = (model, knex, cb) => {
                 });
             }, {});
 
+            // Here we're building the Joi schema for the join table based on all the info we have.
+
             const toFromColumns = {};
             const fromName = joinTableFrom[1]; // columnName
             const toName = joinTableTo[1]; // columnName

--- a/lib/index.js
+++ b/lib/index.js
@@ -637,8 +637,8 @@ internals.getJoinTableInfo = (model, knex, cb) => {
             }, {});
 
             const toFromColumns = {};
-            const fromName = joinTableFrom[1]; // tableName
-            const toName = joinTableTo[1]; // tableName
+            const fromName = joinTableFrom[1]; // columnName
+            const toName = joinTableTo[1]; // columnName
 
             // Turn 'toFromColumns' into Joi keys to add to 'joiSchema' via 'joiSchema.keys()'
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,8 @@ const internals = {};
 
 exports.returnCodes = {
     NO_MIGRATION: 1,
-    MIGRATION: 2
+    MIGRATION: 2,
+    MIGRATION_WITH_CONFLICT: 3
 };
 
 exports.genMigrationFile = (options, cb) => {
@@ -193,7 +194,7 @@ exports.genMigrationFile = (options, cb) => {
                         const template = Fs.readFileSync(__dirname + '/hbs/migrationFileTemplate.hbs').toString();
                         const compiler = internals.handlebars().compile(template);
                         const createdTables = tableDeltas.tableDelta.create.concat(tableDeltas.joinTableDelta.create);
-                        const sameColumn = (skipA, skipB) => skipA.tableName === skipB.tableName && skipA.column === skipB.column;
+                        const sameColumn = (skipA, skipB) => skipA.tableName === skipB.tableName && skipA.column === skipB.column && skipA.schemaConflict === skipB.schemaConflict;
                         const dedupedSkippedCols = skippedCols.filter((skip, i) => {
 
                             return skippedCols.findIndex((s) => sameColumn(s, skip)) === i;
@@ -387,11 +388,24 @@ internals.diffColumns = (migrationGroup, joinTables, mode, cb) => {
                         skippedCols.push({
                             tableName,
                             column,
-                            type
+                            type,
+                            schemaConflict: Object.keys(modelKnexSchema).includes(column)
                         });
                     }
                     return !err;
                 });
+
+            // Filter out any skippedCols from the model's schema so they don't get diffed
+            // Note this is considered a conflict
+            const filteredModelKnex2ColumnCompilerSchema = Object.keys(modelKnex2ColumnCompilerSchema)
+                .reduce((collector, colName) => {
+
+                    const isSkipped = skippedCols.find((sc) => sc.column === colName);
+                    if (!isSkipped) {
+                        collector[colName] = modelKnex2ColumnCompilerSchema[colName];
+                    }
+                    return collector;
+                }, {});
 
             const db2ColumnCompilerSchema = dbColsToConvert.reduce((collector, columnName) => {
 
@@ -406,7 +420,8 @@ internals.diffColumns = (migrationGroup, joinTables, mode, cb) => {
                 return collector;
             }, {});
 
-            // Let's normalize these
+            // Let's normalize these. dbs don't agree on what to name their datatypes,
+            // here we get 'alias vals' to call them all the same thing so we can run a proper diff
             const normalizedDb2ColumnCompilerSchema = Object.keys(db2ColumnCompilerSchema).reduce((collector, keyName) => {
 
                 const currentType = db2ColumnCompilerSchema[keyName];
@@ -420,7 +435,7 @@ internals.diffColumns = (migrationGroup, joinTables, mode, cb) => {
                 return collector;
             }, {});
 
-            const normalizedModelKnex2ColumnCompilerSchema = Object.keys(modelKnex2ColumnCompilerSchema).reduce((collector, keyName) => {
+            const normalizedModelKnex2ColumnCompilerSchema = Object.keys(filteredModelKnex2ColumnCompilerSchema).reduce((collector, keyName) => {
 
                 const currentType = modelKnex2ColumnCompilerSchema[keyName];
 

--- a/lib/mappings.js
+++ b/lib/mappings.js
@@ -77,42 +77,23 @@ exports.convertFuncs.getAliasVal = (type, augmentError) => {
 
 exports.convertFuncs.joi2Knex = (joiSchema, augmentError) => {
 
-    const joiSchemaDescription = joiSchema.describe();
+    const describeChildren = joiSchema.describe().children;
 
     const badChildren = [];
 
-    const columns = Object.keys(joiSchemaDescription.children).reduce((collector, schemaKey) => {
+    const columns = Object.keys(describeChildren).reduce((collector, schemaKey) => {
 
-        const child = joiSchemaDescription.children[schemaKey];
-        const childType = child.type;
-
-        let columnType;
-
-        switch (childType) {
-
-            case 'number':
-
-                const rulesIncludeInteger = child.rules && child.rules.some((rule) => rule.name === 'integer');
-
-                if (rulesIncludeInteger) {
-                    columnType = exports.maps.joiKnexMap.numberInteger;
-                }
-                else {
-                    columnType = exports.maps.joiKnexMap[childType];
-                }
-                break;
-            default:
-                columnType = exports.maps.joiKnexMap[childType];
-        }
+        const child = describeChildren[schemaKey];
+        const type = exports.convertFuncs.stringFromJoiDescribeChild(child);
+        const columnType = exports.maps.joiKnexMap[type];
 
         if (!columnType) {
-            badChildren.push(childType);
+            badChildren.push(type);
             return collector;
         }
 
         collector[schemaKey] = columnType;
         return collector;
-
     }, {});
 
     return internals.multiReturn(
@@ -179,6 +160,26 @@ exports.convertFuncs.string2Joi = (str) => {
         return Joi.number().integer();
     }
     return Joi[str]();
+};
+
+exports.convertFuncs.stringFromJoiDescribeChild = (child) => {
+
+    const { type } = child;
+
+    switch (type) {
+
+        case 'number':
+
+            const rulesIncludeInteger = child.rules && child.rules.some((rule) => rule.name === 'integer');
+
+            if (rulesIncludeInteger) {
+                return 'numberInteger';
+            }
+            return type;
+
+        default:
+            return type;
+    }
 };
 
 internals.multiReturn = (condition, errMsg, val) => {

--- a/test/index.js
+++ b/test/index.js
@@ -558,87 +558,6 @@ describe('SchwiftyMigration', () => {
         });
     });
 
-    it('informs user of conflict between a skipped db column and a Joi schema prop with the same name', (done, onCleanup) => {
-
-        internals.makeSession((err, session) => {
-
-            if (err) {
-                return done(err);
-            }
-
-            internals.testUtils.setupCleanup(onCleanup, session);
-
-            const migrationsDir = './test/migration-tests/migrations';
-            const seedPath = './test/migration-tests/seed';
-
-            session.knex.migrate.latest({
-                directory: seedPath
-            })
-                .asCallback((err) => {
-
-                    if (err) {
-                        return done(err);
-                    }
-
-                    let rawQuery;
-                    let expectedOutput;
-
-                    if (session.isPostgres()) {
-                        rawQuery = 'ALTER TABLE "Person" ADD weirdo_column polygon';
-                        expectedOutput = {
-                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
-                            file: 'test',
-                            skippedColumns: [
-                                { tableName: 'Person', column: 'weirdo_column', type: 'polygon', schemaConflict: true }
-                            ]
-                        };
-                    }
-                    else if (session.isMySql()) {
-                        rawQuery = 'ALTER TABLE Person ADD weirdo_column SET("a", "b", "c")';
-                        expectedOutput = {
-                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
-                            file: 'test',
-                            skippedColumns: [
-                                { tableName: 'Person', column: 'weirdo_column', type: 'set', schemaConflict: true }
-                            ]
-                        };
-                    }
-                    else {
-                        return done(new Error('Db not supported'));
-                    }
-
-                    session.knex.raw(rawQuery)
-                        .asCallback((alterErr) => {
-
-                            if (alterErr) {
-                                return done(alterErr);
-                            }
-
-                            SchwiftyMigration.genMigrationFile({
-                                models: [TestModels.WeirdoPerson],
-                                migrationsDir,
-                                knex: session.knex,
-                                migrationName: 'test'
-                            }, (err, output) => {
-
-                                expect(err).to.not.exist();
-
-                                Utils.validateOutput(output, expectedOutput);
-
-                                Fs.readdirSync(migrationsDir)
-                                    .forEach((migrationFile) => {
-
-                                        const filePath = Path.join(migrationsDir, migrationFile);
-                                        Fs.unlinkSync(filePath);
-                                    });
-
-                                done();
-                            });
-                        });
-                });
-        });
-    });
-
     it('informs user of skipped unsupported db column types and no other changes', (done, onCleanup) => {
 
         internals.makeSession((err, session) => {
@@ -782,6 +701,171 @@ describe('SchwiftyMigration', () => {
                                 models: [
                                     TestModels.Person,
                                     TestModels.Movie
+                                ],
+                                migrationsDir,
+                                knex: session.knex,
+                                migrationName: 'test'
+                            }, (err, output) => {
+
+                                expect(err).to.not.exist();
+
+                                Utils.validateOutput(output, expectedOutput);
+
+                                Fs.readdirSync(migrationsDir)
+                                    .forEach((migrationFile) => {
+
+                                        const filePath = Path.join(migrationsDir, migrationFile);
+                                        Fs.unlinkSync(filePath);
+                                    });
+
+                                done();
+                            });
+                        });
+                });
+        });
+    });
+
+    it('informs user of a schema conflict between a skipped db column and a Joi schema prop with the same name', (done, onCleanup) => {
+
+        internals.makeSession((err, session) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            internals.testUtils.setupCleanup(onCleanup, session);
+
+            const migrationsDir = './test/migration-tests/migrations';
+            const seedPath = './test/migration-tests/seed';
+
+            session.knex.migrate.latest({
+                directory: seedPath
+            })
+                .asCallback((err) => {
+
+                    if (err) {
+                        return done(err);
+                    }
+
+                    let rawQuery;
+                    let expectedOutput;
+
+                    if (session.isPostgres()) {
+                        rawQuery = 'ALTER TABLE "Person" ADD weirdo_column polygon';
+                        expectedOutput = {
+                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
+                            file: 'test',
+                            skippedColumns: [
+                                { tableName: 'Person', column: 'weirdo_column', type: 'polygon', schemaConflict: true }
+                            ]
+                        };
+                    }
+                    else if (session.isMySql()) {
+                        rawQuery = 'ALTER TABLE Person ADD weirdo_column SET("a", "b", "c")';
+                        expectedOutput = {
+                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
+                            file: 'test',
+                            skippedColumns: [
+                                { tableName: 'Person', column: 'weirdo_column', type: 'set', schemaConflict: true }
+                            ]
+                        };
+                    }
+                    else {
+                        return done(new Error('Db not supported'));
+                    }
+
+                    session.knex.raw(rawQuery)
+                        .asCallback((alterErr) => {
+
+                            if (alterErr) {
+                                return done(alterErr);
+                            }
+
+                            SchwiftyMigration.genMigrationFile({
+                                models: [TestModels.WeirdoPerson],
+                                migrationsDir,
+                                knex: session.knex,
+                                migrationName: 'test'
+                            }, (err, output) => {
+
+                                expect(err).to.not.exist();
+
+                                Utils.validateOutput(output, expectedOutput);
+
+                                Fs.readdirSync(migrationsDir)
+                                    .forEach((migrationFile) => {
+
+                                        const filePath = Path.join(migrationsDir, migrationFile);
+                                        Fs.unlinkSync(filePath);
+                                    });
+
+                                done();
+                            });
+                        });
+                });
+        });
+    });
+
+    it('informs user of a schema conflict between a skipped db column and a Joi schema prop with the same name on a join table', (done, onCleanup) => {
+
+        internals.makeSession((err, session) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            internals.testUtils.setupCleanup(onCleanup, session);
+
+            const migrationsDir = './test/migration-tests/migrations';
+            const seedPath = './test/migration-tests/seed-join';
+
+            session.knex.migrate.latest({
+                directory: seedPath
+            })
+                .asCallback((err) => {
+
+                    if (err) {
+                        return done(err);
+                    }
+
+                    let rawQuery;
+                    let expectedOutput;
+
+                    if (session.isPostgres()) {
+                        rawQuery = 'ALTER TABLE "Person_Movie" ADD weirdo_column polygon';
+                        expectedOutput = {
+                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
+                            file: 'test',
+                            skippedColumns: [
+                                { tableName: 'Person_Movie', column: 'weirdo_column', type: 'polygon', schemaConflict: true }
+                            ]
+                        };
+                    }
+                    else if (session.isMySql()) {
+                        rawQuery = 'ALTER TABLE Person_Movie ADD weirdo_column SET("a", "b", "c")';
+                        expectedOutput = {
+                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
+                            file: 'test',
+                            skippedColumns: [
+                                { tableName: 'Person_Movie', column: 'weirdo_column', type: 'set', schemaConflict: true }
+                            ]
+                        };
+                    }
+                    else {
+                        return done(new Error('Db not supported'));
+                    }
+
+                    session.knex.raw(rawQuery)
+                        .asCallback((alterErr) => {
+
+                            if (alterErr) {
+                                return done(alterErr);
+                            }
+
+                            SchwiftyMigration.genMigrationFile({
+                                models: [
+                                    TestModels.Person,
+                                    TestModels.MovieWithWeirdoJoin
                                 ],
                                 migrationsDir,
                                 knex: session.knex,

--- a/test/index.js
+++ b/test/index.js
@@ -508,7 +508,7 @@ describe('SchwiftyMigration', () => {
                             code: SchwiftyMigration.returnCodes.MIGRATION,
                             file: 'test',
                             skippedColumns: [
-                                { tableName: 'Person', column: 'weirdo_psql_column', type: 'polygon' }
+                                { tableName: 'Person', column: 'weirdo_psql_column', type: 'polygon', schemaConflict: false }
                             ]
                         };
                     }
@@ -518,7 +518,7 @@ describe('SchwiftyMigration', () => {
                             code: SchwiftyMigration.returnCodes.MIGRATION,
                             file: 'test',
                             skippedColumns: [
-                                { tableName: 'Person', column: 'weirdo_mysql_column', type: 'set' }
+                                { tableName: 'Person', column: 'weirdo_mysql_column', type: 'set', schemaConflict: false }
                             ]
                         };
                     }
@@ -535,6 +535,87 @@ describe('SchwiftyMigration', () => {
 
                             SchwiftyMigration.genMigrationFile({
                                 models: [TestModels.AlterPerson],
+                                migrationsDir,
+                                knex: session.knex,
+                                migrationName: 'test'
+                            }, (err, output) => {
+
+                                expect(err).to.not.exist();
+
+                                Utils.validateOutput(output, expectedOutput);
+
+                                Fs.readdirSync(migrationsDir)
+                                    .forEach((migrationFile) => {
+
+                                        const filePath = Path.join(migrationsDir, migrationFile);
+                                        Fs.unlinkSync(filePath);
+                                    });
+
+                                done();
+                            });
+                        });
+                });
+        });
+    });
+
+    it('informs user of conflict between a skipped db column and a Joi schema prop with the same name', (done, onCleanup) => {
+
+        internals.makeSession((err, session) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            internals.testUtils.setupCleanup(onCleanup, session);
+
+            const migrationsDir = './test/migration-tests/migrations';
+            const seedPath = './test/migration-tests/seed';
+
+            session.knex.migrate.latest({
+                directory: seedPath
+            })
+                .asCallback((err) => {
+
+                    if (err) {
+                        return done(err);
+                    }
+
+                    let rawQuery;
+                    let expectedOutput;
+
+                    if (session.isPostgres()) {
+                        rawQuery = 'ALTER TABLE "Person" ADD weirdo_column polygon';
+                        expectedOutput = {
+                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
+                            file: 'test',
+                            skippedColumns: [
+                                { tableName: 'Person', column: 'weirdo_column', type: 'polygon', schemaConflict: true }
+                            ]
+                        };
+                    }
+                    else if (session.isMySql()) {
+                        rawQuery = 'ALTER TABLE Person ADD weirdo_column SET("a", "b", "c")';
+                        expectedOutput = {
+                            code: SchwiftyMigration.returnCodes.MIGRATION_WITH_CONFLICT,
+                            file: 'test',
+                            skippedColumns: [
+                                { tableName: 'Person', column: 'weirdo_column', type: 'set', schemaConflict: true }
+                            ]
+                        };
+                    }
+                    else {
+                        return done(new Error('Db not supported'));
+                    }
+
+                    session.knex.raw(rawQuery)
+                        .asCallback((alterErr) => {
+
+                            if (alterErr) {
+                                return done(alterErr);
+                            }
+
+                            SchwiftyMigration.genMigrationFile({
+                                models: [TestModels.WeirdoPerson],
                                 migrationsDir,
                                 knex: session.knex,
                                 migrationName: 'test'
@@ -589,7 +670,7 @@ describe('SchwiftyMigration', () => {
                             code: SchwiftyMigration.returnCodes.NO_MIGRATION,
                             file: null,
                             skippedColumns: [
-                                { tableName: 'Person', column: 'weirdo_psql_column', type: 'polygon' }
+                                { tableName: 'Person', column: 'weirdo_psql_column', type: 'polygon', schemaConflict: false }
                             ]
                         };
                     }
@@ -599,7 +680,7 @@ describe('SchwiftyMigration', () => {
                             code: SchwiftyMigration.returnCodes.NO_MIGRATION,
                             file: null,
                             skippedColumns: [
-                                { tableName: 'Person', column: 'weirdo_mysql_column', type: 'set' }
+                                { tableName: 'Person', column: 'weirdo_mysql_column', type: 'set', schemaConflict: false }
                             ]
                         };
                     }
@@ -670,8 +751,8 @@ describe('SchwiftyMigration', () => {
                             code: SchwiftyMigration.returnCodes.NO_MIGRATION,
                             file: null,
                             skippedColumns: [
-                                { tableName: 'Person_Movie', column: 'weirdo_psql_column', type: 'polygon' },
-                                { tableName: 'Person', column: 'weirdo_psql_column', type: 'polygon' }
+                                { tableName: 'Person_Movie', column: 'weirdo_psql_column', type: 'polygon', schemaConflict: false },
+                                { tableName: 'Person', column: 'weirdo_psql_column', type: 'polygon', schemaConflict: false }
                             ]
                         };
                     }
@@ -681,8 +762,8 @@ describe('SchwiftyMigration', () => {
                             code: SchwiftyMigration.returnCodes.NO_MIGRATION,
                             file: null,
                             skippedColumns: [
-                                { tableName: 'Person_Movie', column: 'weirdo_mysql_column', type: 'set' },
-                                { tableName: 'Person', column: 'weirdo_mysql_column', type: 'set' }
+                                { tableName: 'Person_Movie', column: 'weirdo_mysql_column', type: 'set', schemaConflict: false },
+                                { tableName: 'Person', column: 'weirdo_mysql_column', type: 'set', schemaConflict: false }
                             ]
                         };
                     }

--- a/test/migration-tests/integrated/1-create-alter-drop-with-join/seed/20170928131233_integration-seed.js
+++ b/test/migration-tests/integrated/1-create-alter-drop-with-join/seed/20170928131233_integration-seed.js
@@ -27,5 +27,6 @@ exports.down = function (knex, Promise) {
 
     return knex.schema
         .dropTable('Person')
-        .dropTable('Movie');
+        .dropTable('Movie')
+        .dropTable('Dog_Movie');
 };

--- a/test/migration-tests/models/bad-person.js
+++ b/test/migration-tests/models/bad-person.js
@@ -19,7 +19,7 @@ module.exports = class BadPerson extends Model {
 
             age: Joi.number().integer(),
 
-            // These cannot be different types, they must be the same type
+            // This Joi is unsupported, these must be the same type
             address: Joi.alternatives([
                 Joi.string(),
                 Joi.object()

--- a/test/migration-tests/models/double-bad-person-movie.js
+++ b/test/migration-tests/models/double-bad-person-movie.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const Model = require('schwifty').Model;
 
-module.exports = class Person_Movie extends Model {
+module.exports = class Double_Bad_Person_Movie extends Model {
 
     static get tableName() {
 

--- a/test/migration-tests/models/index.js
+++ b/test/migration-tests/models/index.js
@@ -3,14 +3,16 @@
 exports.AlterPerson = require('./alter-person');
 exports.Bad_Person_Movie = require('./bad-person-movie');
 exports.BadMovie = require('./bad-movie');
-exports.BadMovieWithBadPersonRef = require('./bad-movie-with-bad-person-ref');
+exports.MovieWithBadPerson = require('./movie-with-bad-person');
 exports.BadPerson = require('./bad-person');
 exports.BadZombie = require('./bad-zombie');
 exports.Dog = require('./dog');
 exports.Double_Bad_Person_Movie = require('./double-bad-person-movie');
 exports.DoubleBadMovie = require('./double-bad-movie');
 exports.Movie = require('./movie');
+exports.MovieWithWeirdoJoin = require('./movie-with-weirdo-join');
 exports.Person_Movie = require('./person-movie');
 exports.Person = require('./person');
 exports.WeirdoPerson = require('./weirdo-person');
+exports.Weirdo_Person_Movie = require('./weirdo-person-movie');
 exports.Zombie = require('./zombie');

--- a/test/migration-tests/models/index.js
+++ b/test/migration-tests/models/index.js
@@ -12,4 +12,5 @@ exports.DoubleBadMovie = require('./double-bad-movie');
 exports.Movie = require('./movie');
 exports.Person_Movie = require('./person-movie');
 exports.Person = require('./person');
+exports.WeirdoPerson = require('./weirdo-person');
 exports.Zombie = require('./zombie');

--- a/test/migration-tests/models/movie-with-bad-person.js
+++ b/test/migration-tests/models/movie-with-bad-person.js
@@ -4,11 +4,11 @@ const Joi = require('joi');
 const Model = require('schwifty').Model;
 const TestModels = require('./');
 
-module.exports = class BadMovieWithBadPersonRef extends Model {
+module.exports = class MovieWithBadPerson extends Model {
 
     static get tableName() {
 
-        return 'BadMovieWithBadPersonRef';
+        return 'MovieWithBadPerson';
     }
 
     static get joiSchema() {
@@ -37,7 +37,7 @@ module.exports = class BadMovieWithBadPersonRef extends Model {
                         to: 'Person_Movie.movieId',
                         modelClass: TestModels.Person_Movie
                     },
-                    to: 'BadMovieWithBadPersonRef.id'
+                    to: 'MovieWithBadPerson.id'
                 }
             }
         };

--- a/test/migration-tests/models/movie-with-weirdo-join.js
+++ b/test/migration-tests/models/movie-with-weirdo-join.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const Joi = require('joi');
+const Model = require('schwifty').Model;
+const TestModels = require('./');
+
+module.exports = class MovieWithWeirdoJoin extends Model {
+
+    static get tableName() {
+
+        return 'Movie';
+    }
+
+    static get joiSchema() {
+
+        return Joi.object({
+            id: Joi.number(),
+            title: Joi.string(),
+            subTitle: Joi.string()
+        });
+    }
+
+    static get relationMappings() {
+
+        return {
+            actors: {
+                relation: Model.ManyToManyRelation,
+                modelClass: TestModels.Person,
+                join: {
+                    from: 'Person.id',
+                    through: {
+                        from: 'Person_Movie.personId',
+                        to: 'Person_Movie.movieId',
+                        modelClass: TestModels.Weirdo_Person_Movie
+                    },
+                    to: 'Movie.id'
+                }
+            }
+        };
+    }
+};

--- a/test/migration-tests/models/weirdo-movie.js
+++ b/test/migration-tests/models/weirdo-movie.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Joi = require('joi');
+const Model = require('schwifty').Model;
+const TestModels = require('./');
+
+module.exports = class WeirdoMovie extends Model {
+
+    static get tableName() {
+
+        return 'WeirdoMovie';
+    }
+
+    static get joiSchema() {
+
+        return Joi.object({
+            id: Joi.number(),
+            title: Joi.string(),
+            subTitle: Joi.string()
+        });
+    }
+
+    static get relationMappings() {
+
+        return {
+            actors: {
+                relation: Model.ManyToManyRelation,
+                modelClass: TestModels.Person,
+                join: {
+                    from: 'Person.id',
+                    through: {
+                        from: 'Person_Movie.personId',
+                        to: 'Person_Movie.movieId'
+                    },
+                    to: 'Movie.id'
+                }
+            }
+        };
+    }
+};

--- a/test/migration-tests/models/weirdo-person-movie.js
+++ b/test/migration-tests/models/weirdo-person-movie.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const Joi = require('joi');
+const Model = require('schwifty').Model;
+
+module.exports = class Weirdo_Person_Movie extends Model {
+
+    static get tableName() {
+
+        return 'Person_Movie';
+    }
+
+    static get joiSchema() {
+
+        return Joi.object({
+            personId: Joi.number(),
+            movieId: Joi.number(),
+            weirdo_column: Joi.string() // This conflicts with an unsupported (skipped) weirdo_column in the db
+        });
+    }
+};

--- a/test/migration-tests/models/weirdo-person.js
+++ b/test/migration-tests/models/weirdo-person.js
@@ -27,7 +27,8 @@ module.exports = class AlterPerson extends Model {
                 zipCode: Joi.string()
             }),
 
-            hometown: Joi.string() // This will be the only thing reflected in the migration file
+            hometown: Joi.string(),
+            weirdo_column: Joi.string() // This conflicts with an unsupported (skipped) weirdo_column in the db
         });
     }
 };

--- a/test/migration-tests/models/weirdo-person.js
+++ b/test/migration-tests/models/weirdo-person.js
@@ -3,10 +3,7 @@
 const Joi = require('joi');
 const Model = require('schwifty').Model;
 
-// This model intended for use with test 'Suppresses alter and drop actions if mode is not set to "alter"'
-// Any alters should be ignored, this migration will be run with `mode: 'create'`
-
-module.exports = class AlterPerson extends Model {
+module.exports = class WeirdoPerson extends Model {
 
     static get tableName() {
 
@@ -17,7 +14,7 @@ module.exports = class AlterPerson extends Model {
 
         return Joi.object({
             id: Joi.number().integer(),
-            firstName: Joi.number(), // It's the future, all firstNames are numbers now // This will be ignored
+            firstName: Joi.number(),
 
             age: Joi.number().integer(),
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -14,7 +14,7 @@ module.exports = {
         expect(output).to.exist();
         expect(output.code).to.equal(expectedOutput.code);
         expect(output.skippedColumns).to.equal(expectedOutput.skippedColumns);
-        expect(output.schemaConflict).to.equal(expectedOutput.schemaConflict);
+
         output.file && expect(output.file).to.endWith(`${expectedOutput.file}.js`);
     },
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -14,6 +14,7 @@ module.exports = {
         expect(output).to.exist();
         expect(output.code).to.equal(expectedOutput.code);
         expect(output.skippedColumns).to.equal(expectedOutput.skippedColumns);
+        expect(output.schemaConflict).to.equal(expectedOutput.schemaConflict);
         output.file && expect(output.file).to.endWith(`${expectedOutput.file}.js`);
     },
 


### PR DESCRIPTION
- Introduce new return code: `MIGRATION_WITH_CONFLICT` to inform the user that they have a Joi schema prop that conflicts with a skipped, unsupported db column
- Introduce `schemaConflict` property on all `skippedCols` entries so a user can search for which columns are an issue